### PR TITLE
Fix colours in whatsthis dialogue for dark display theme

### DIFF
--- a/kflog/whatsthat.cpp
+++ b/kflog/whatsthat.cpp
@@ -104,19 +104,14 @@ void WhatsThat::leaveEvent( QEvent* )
 
 void WhatsThat::paintEvent( QPaintEvent* )
 {
-  QPixmap pm = QPixmap( docW+1, docH+1 );
-  pm.fill(QColor(255, 255, 224)); // LightYellow www.wackerart.de/rgbfarben.html
-
-  QPainter docP;
-
-  docP.begin(&pm);
-  doc->drawContents( &docP );
-  docP.end();
-
   QPainter p( this );
-  p.fillRect( rect(), Qt::red );
-
-  p.drawPixmap( hMargin, vMargin, pm );
+  QPen borderPen(Qt::red);
+  borderPen.setWidth(5);
+  p.setPen(borderPen);
+  p.drawRect(rect());
+  p.setBrush(palette().window());
+  p.setPen(QPen(palette().text(), 1));
+  doc->drawContents( &p );
 }
 
 /** Tries to find itself a good position to display. */


### PR DESCRIPTION
On dark dispays, the "whatsthat" dialoge has white text on a white background:
![kflog-white-on-white](https://user-images.githubusercontent.com/14142329/233848533-20d7b041-82ce-4cb7-8e20-e92feb2e2ffe.png)
This PR fixes the colours: It uses the system colours for the dialogue, and draws a red border around it:
![kflog-info-fixed-colour](https://user-images.githubusercontent.com/14142329/233848596-bdc2fef3-5ffd-404e-abf3-27392d9bb26a.png)
